### PR TITLE
Track all Lineage's Webview repos

### DIFF
--- a/los.xml
+++ b/los.xml
@@ -12,7 +12,14 @@
   <project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" revision="lineage-19.0" remote="lineage" />
   <project path="external/ant-wireless/hidl" name="android_external_ant-wireless_hidl" groups="qcom,qssi" remote="lineage" />
   <project path="external/bash" name="android_external_bash" remote="lineage" />
+  <project path="external/chromium-webview/patches" name="android_external_chromium-webview_patches" groups="pdk" remote="lineage" revision="main" >
+    <linkfile src="Android.mk" dest="external/chromium-webview/Android.mk" />
+    <linkfile src="CleanSpec.mk" dest="external/chromium-webview/CleanSpec.mk" />
+    <linkfile src="README" dest="external/chromium-webview/README" />
+  </project>
+  <project path="external/chromium-webview/prebuilt/arm" name="android_external_chromium-webview_prebuilt_arm" groups="pdk" remote="lineage" clone-depth="1" revision="main" />
   <project path="external/chromium-webview/prebuilt/arm64" name="android_external_chromium-webview_prebuilt_arm64" groups="pdk" remote="lineage" clone-depth="1" revision="main" />
+  <project path="external/chromium-webview/prebuilt/x86" name="android_external_chromium-webview_prebuilt_x86" groups="pdk" remote="lineage" clone-depth="1" revision="main" />
   <project path="external/libncurses" name="android_external_libncurses" remote="lineage" />
   <project path="external/libnl" name="android_external_libnl" groups="pdk" remote="lineage" />
   <project path="external/libcxx" name="android_external_libcxx" groups="pdk" remote="lineage" />

--- a/remove.xml
+++ b/remove.xml
@@ -73,6 +73,7 @@
   <remove-project name="device/sample" />
 
   <!-- External -->
+  <remove-project name="platform/external/chromium-webview" />
   <remove-project name="platform/external/gptfdisk" />
   <remove-project name="platform/external/libcxx" />
   <remove-project name="platform/external/libnl" />


### PR DESCRIPTION
I don't know why only arm64 is being pulled, but we should include the rest of the webview arch & the repo contain Android.mk itself

This also fixes the recent android.window.extensions requirement

Change-Id: I8382b8605240f154fd1ee56f8ea52e99018ebc00